### PR TITLE
feat: Performance e Cache #56

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,3 +33,7 @@ AUTH_SECRET=change-me-in-production
 AUTH_KEYCLOAK_ID=cbn-frontend
 AUTH_KEYCLOAK_SECRET=change-me-in-production
 AUTH_KEYCLOAK_ISSUER=http://localhost:8080/realms/cbn
+
+# --- Revalidation ---
+NEXTJS_URL=http://frontend:3000 # Ou a URL do container do seu frontend
+REVALIDATION_SECRET=minha_senha_super_secreta_123

--- a/content/apps.py
+++ b/content/apps.py
@@ -2,4 +2,9 @@ from django.apps import AppConfig
 
 
 class ContentConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
     name = 'content'
+
+    def ready(self):
+        # Quando o app iniciar, os signals começam a vigiar o modelo Post
+        import content.signals

--- a/content/signals.py
+++ b/content/signals.py
@@ -1,0 +1,67 @@
+import logging
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+from django.db.models.signals import post_save, post_delete
+from django.dispatch import receiver
+from django.conf import settings
+from .models import Post, PostStatus
+
+logger = logging.getLogger(__name__)
+
+def get_retry_session():
+    """Configura uma sessão HTTP com política de retry automático e backoff."""
+    session = requests.Session()
+    
+    # Configuração do Retry:
+    # total=2: Tenta a original + 2 retries (Total de 3 tentativas)
+    # backoff_factor=0.3: Espera 0s (1ª), 0.3s (2ª) e 0.6s (3ª tentativa) para não travar o admin
+    # status_forcelist: Só repete se o Next.js estiver fora do ar ou engasgado (erros 5xx)
+    retry_strategy = Retry(
+        total=2,
+        backoff_factor=0.3,
+        status_forcelist=[500, 502, 503, 504],
+        allowed_methods=["POST"]
+    )
+    
+    adapter = HTTPAdapter(max_retries=retry_strategy)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    
+    return session
+
+def revalidate_nextjs_cache(slug):
+    """Envia um POST para o webhook do Next.js usando uma sessão com Retry."""
+    if not getattr(settings, 'REVALIDATION_SECRET', None) or not getattr(settings, 'NEXTJS_URL', None):
+        logger.warning(f"Credenciais do Next.js ausentes. Cache não revalidado para: {slug}")
+        return
+
+    url = f"{settings.NEXTJS_URL}/api/revalidate"
+    headers = {"x-reval-secret": settings.REVALIDATION_SECRET}
+    payload = {"tags": [f"post-{slug}"]}
+
+    # Criamos a sessão blindada com as nossas regras de Retry
+    session = get_retry_session()
+
+    try:
+        # Timeout de 2.0s se aplica a CADA tentativa. 
+        # No pior cenário (3 falhas seguidas), o admin do Django demora no máximo uns 6s.
+        response = session.post(url, json=payload, headers=headers, timeout=2.0)
+        response.raise_for_status()
+        logger.info(f"Cache revalidado com sucesso no Next.js para o post: {slug}")
+        
+    except requests.exceptions.RequestException as e:
+        # Se esgotar todos os retries ou der erro de conexão persistente, falha silenciosamente
+        logger.error(f"Falha definitiva ao revalidar cache do Next.js para {slug} após tentativas: {str(e)}")
+
+
+@receiver(post_save, sender=Post)
+def trigger_revalidation_on_save(sender, instance, created, **kwargs):
+    if created and instance.status == PostStatus.DRAFT:
+        return
+    revalidate_nextjs_cache(instance.slug)
+
+
+@receiver(post_delete, sender=Post)
+def trigger_revalidation_on_delete(sender, instance, **kwargs):
+    revalidate_nextjs_cache(instance.slug)

--- a/content/tests/test_signals_revalidation.py
+++ b/content/tests/test_signals_revalidation.py
@@ -1,0 +1,62 @@
+import pytest
+from unittest.mock import patch
+from django.contrib.auth.models import User
+
+from accounts.models import Author
+from content.models import Post, PostStatus
+
+# Avisa ao pytest que esses testes precisam acessar o banco de dados
+pytestmark = pytest.mark.django_db
+
+
+# O @patch continua aqui, interceptando a nossa Sessão HTTP com Retry antes dela ir pra internet
+@patch('requests.Session.post')
+def test_revalidation_called_on_published_post(mock_post):
+    """Garante que salvar um post PUBLICADO dispara o webhook com a tag correta"""
+    
+    # 1. Configuração (Setup)
+    user = User.objects.create_user(username='autor-webhook', password='secret')
+    author = Author.objects.create(user=user, name='Autor Webhook')
+
+    # 2. Ação
+    Post.objects.create(
+        title='Notícia Urgente',
+        subtitle='Sub',
+        slug='noticia-urgente',
+        content='Conteudo',
+        author=author,
+        status=PostStatus.PUBLISHED,
+    )
+
+    # 3. Verificações (Asserts)
+    # Garante que o método post() foi chamado
+    assert mock_post.called is True, "O webhook deveria ter sido chamado ao publicar um post."
+    
+    # Captura os argumentos que foram passados para o mock
+    args, kwargs = mock_post.call_args
+    
+    # Garante que o JSON enviado tem a tag correta
+    assert kwargs['json']['tags'] == ['post-noticia-urgente']
+
+
+@patch('requests.Session.post')
+def test_revalidation_not_called_on_new_draft(mock_post):
+    """Garante que criar um RASCUNHO novo não dispara o webhook"""
+    
+    # 1. Configuração (Setup)
+    user = User.objects.create_user(username='autor-rascunho', password='secret')
+    author = Author.objects.create(user=user, name='Autor Rascunho')
+
+    # 2. Ação
+    Post.objects.create(
+        title='Rascunho Incompleto',
+        subtitle='Sub',
+        slug='rascunho-incompleto',
+        content='Ainda escrevendo...',
+        author=author,
+        status=PostStatus.DRAFT,
+    )
+
+    # 3. Verificação (Assert)
+    # Garante que o método post() NÃO foi chamado
+    assert mock_post.called is False, "O webhook NÃO deveria ser chamado ao criar rascunhos."

--- a/core/settings.py
+++ b/core/settings.py
@@ -239,3 +239,7 @@ CACHES = {
         'TIMEOUT': 300,
     }
 }
+
+# Configurações para Revalidação de Páginas Estáticas no Next.js
+NEXTJS_URL = os.getenv("NEXTJS_URL", "http://localhost:3000")
+REVALIDATION_SECRET = os.getenv("REVALIDATION_SECRET", "")

--- a/frontend/src/app/[slug]/page.tsx
+++ b/frontend/src/app/[slug]/page.tsx
@@ -6,7 +6,12 @@ import { fetchAPI } from '@/lib/api';
 import { sanitizeRichTextHtml } from '@/lib/rich-text-policy';
 import type { PostDetail } from '@/types';
 
-export const dynamic = 'force-dynamic';
+//export const dynamic = 'force-dynamic';
+
+// 🚀 A MÁGICA DO FALLBACK AQUI:
+// Se o webhook do Django falhar, o Next.js vai revalidar a página sozinho 
+// após 86400 segundos (24 horas) quando receber um novo acesso.
+export const revalidate = 86400;
 
 interface PageProps {
   params: Promise<{ slug: string }>;
@@ -14,7 +19,11 @@ interface PageProps {
 
 async function getPost(slug: string): Promise<PostDetail | null> {
   try {
-    return await fetchAPI<PostDetail>(`/posts/${slug}/`);
+    // Agora estamos forçando o cache e colando a "etiqueta" (tag) na requisição!
+    return await fetchAPI<PostDetail>(`/posts/${slug}/`, {
+      cache: 'force-cache',
+      next: { tags: [`post-${slug}`] },
+    });
   } catch {
     return null;
   }

--- a/frontend/src/app/api/revalidate/route.ts
+++ b/frontend/src/app/api/revalidate/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { revalidateTag } from 'next/cache';
+
+export async function POST(request: NextRequest) {
+  // 1. Proteção contra falha humana: E se esquecermos de colocar a senha no .env?
+  if (!process.env.REVALIDATION_SECRET) {
+    console.error('CRÍTICO: REVALIDATION_SECRET não configurado no .env do frontend.');
+    return NextResponse.json({ message: 'Erro de configuração do servidor' }, { status: 500 });
+  }
+
+  // 2. Pegamos a senha enviada pelo Django e validamos
+  const secret = request.headers.get('x-reval-secret');
+  if (secret !== process.env.REVALIDATION_SECRET) {
+    console.warn('Tentativa de revalidação com token inválido bloqueada.');
+    return NextResponse.json({ message: 'Token inválido' }, { status: 401 });
+  }
+
+  try {
+    const body = await request.json();
+    
+    // 3. Agora esperamos um ARRAY de tags. Ex: { "tags": ["post-123", "home", "cat-politica"] }
+    const tagsToRevalidate = body.tags;
+
+    // Validamos se realmente chegou um array e se ele não está vazio
+    if (!tagsToRevalidate || !Array.isArray(tagsToRevalidate) || tagsToRevalidate.length === 0) {
+      return NextResponse.json({ message: 'Array de "tags" não fornecido ou vazio' }, { status: 400 });
+    }
+
+    // 4. A mágica acontece em loop: O Next.js limpa o cache de TODAS as tags solicitadas!
+    tagsToRevalidate.forEach((tag) => {
+      revalidateTag(tag, undefined as any);
+      console.log(`[Cache] Tag revalidada: ${tag}`);
+    });
+
+    return NextResponse.json({ revalidated: true, tags: tagsToRevalidate, now: Date.now() });
+    
+  } catch (err) {
+    // 5. Se algo explodir, registramos o erro no console do servidor para debug
+    console.error('[Cache] Erro no webhook de revalidação:', err);
+    return NextResponse.json({ message: 'Erro ao processar a requisição' }, { status: 500 });
+  }
+}

--- a/frontend/src/app/categoria/[slug]/page.tsx
+++ b/frontend/src/app/categoria/[slug]/page.tsx
@@ -4,7 +4,8 @@ import type { Category, PaginatedResponse, PostSummary } from '@/types';
 import PostCard from '@/components/PostCard';
 import Link from 'next/link';
 
-export const dynamic = 'force-dynamic';
+export const revalidate = 300; // Atualiza a cada 5 minutos (300 segundos)
+//export const dynamic = 'force-dynamic';
 
 interface PageProps {
   params: Promise<{ slug: string }>;

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -2,7 +2,8 @@ import { fetchAPI } from '@/lib/api';
 import type { HomeSection as HomeSectionType } from '@/types';
 import HomeSection from '@/components/HomeSection';
 
-export const dynamic = 'force-dynamic';
+export const revalidate = 60; // O Next.js vai recriar a Home no background a cada 60 segundos
+//export const dynamic = 'force-dynamic';
 
 export default async function HomePage() {
   let sections: HomeSectionType[] = [];

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,14 +1,24 @@
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
 const INTERNAL_API_URL = process.env.INTERNAL_API_URL || 'http://api:8000';
 
-export async function fetchAPI<T>(path: string, options?: RequestInit & { revalidate?: number }): Promise<T> {
+// 1. Adicionamos 'tags?: string[]' na tipagem das opções
+export async function fetchAPI<T>(
+  path: string, 
+  options?: RequestInit & { revalidate?: number; tags?: string[] }
+): Promise<T> {
   const isServer = typeof window === 'undefined';
   const baseUrl = isServer ? INTERNAL_API_URL : API_URL;
-  const { revalidate, ...fetchOptions } = options || {};
+  
+  // 2. Extraímos 'tags' e 'revalidate' de dentro de options
+  const { revalidate, tags, ...fetchOptions } = options || {};
   
   const res = await fetch(`${baseUrl}/api/v1${path}`, {
     ...fetchOptions,
-    next: revalidate !== undefined ? { revalidate } : undefined,
+    // 3. Construímos o objeto 'next' dinamicamente
+    next: {
+      ...(revalidate !== undefined && { revalidate }),
+      ...(tags !== undefined && { tags }),
+    },
   });
   
   if (!res.ok) {


### PR DESCRIPTION
# 🏗️ Decisões Técnicas
## 1. Back-end (Django - App content)
Gatilho via Signals: Utilizamos o post_save e post_delete no modelo Post para interceptar mudanças no banco de dados, independente de onde a edição ocorra (Painel Admin, API ou scripts).

Filtro de Rascunhos: O disparo só ocorre para conteúdos que afetam o front-end (ignora a criação de novos rascunhos com status = DRAFT).

Resiliência e Observabilidade: * A chamada HTTP para o Next.js é síncrona, mas protegida com um timeout agressivo de 2.0s para não congelar o painel do jornalista.

Implementamos uma política de Retry automático via urllib3 (3 tentativas com backoff progressivo) para mitigar instabilidades de rede e erros temporários do container do front-end (Erros 5xx).

Falhas definitivas são capturadas silenciosamente e registradas nos logs (logger.error), garantindo que a notícia seja salva no banco de dados mesmo se o Next.js estiver fora do ar.

## 2. Front-end (Next.js 16 - App Router)
Tag-based Revalidation: A requisição de fetch do post no page.tsx agora recebe uma tag única (next: { tags: ['post-{slug}'] }). O endpoint /api/revalidate usa essa tag para invalidar apenas a página exata que foi alterada, poupando recursos do servidor.

Segurança: O endpoint de revalidação está protegido por um secret (REVALIDATION_SECRET) validado via headers.

Mitigação de Risco (Fallback por tempo): Adicionamos export const revalidate = 86400 (24 horas) nas rotas de Post. Se o webhook do Django falhar todas as tentativas de retry, a página fará uma revalidação automática via ISR uma vez por dia, garantindo que não teremos stale content permanente.

### 🧪 Como testar localmente
Para garantir que a comunicação entre os containers Docker está funcionando, siga este passo a passo:

### 1. Configuração do Ambiente:

No arquivo .env do Django, certifique-se de ter as variáveis:

```bash
NEXTJS_URL=http://frontend:3000 # Nome do serviço do Next no docker-compose
REVALIDATION_SECRET=sua_senha_secreta
Garanta que o .env do Next.js possui o mesmo REVALIDATION_SECRET.
```

### 2. O Teste de Fluxo:

Suba os containers (make up).

Acesse o painel de administração do Django e edite o título ou conteúdo de uma notícia (Post) já publicada.

Clique em "Salvar".

## 3. Validação dos Logs:

Olhe o terminal do container do Django. Você deve ver a mensagem de sucesso:

```bash
INFO: content.signals - Cache revalidado com sucesso no Next.js para o post: [slug-do-post]
```

## 4. Validação Visual:

Abra a página da notícia no front-end.

Atenção: Como estamos testando localmente sem a CDN, o seu navegador pode guardar o cache da página antiga. Para ver a alteração:

Pressione F12 > Vá na aba Network (Rede) > Marque Disable cache.

Dê um F5 normal. A nova versão do texto deve aparecer instantaneamente!

☁️ Próximos Passos (Configuração Cloudflare - Etapa 4)
Nota para Infraestrutura/DevOps: As configurações abaixo devem ser aplicadas no painel da Cloudflare quando a aplicação for para o ambiente de Staging/Produção.

O Next.js já está limpando o próprio cache interno, mas precisamos garantir que a Cloudflare (Cache de Borda) respeite essa atualização e não entregue HTML obsoleto.

### Ações Necessárias na Cloudflare:

Criar Regras de Cache (Cache Rules):

Devemos criar uma regra específica para requisições de páginas HTML (rotas do Next.js como /, /categoria/*, /[slug]).

Configuração: Definir o comportamento de cache para Bypass (Ignorar o cache da Cloudflare e ir direto no servidor) OU Respect Origin Headers (Respeitar estritamente o Cache-Control enviado pelo Next.js).

Assets Estáticos (Imagens, CSS, JS):

Manter o cache agressivo da Cloudflare ativado normalmente para extensões estáticas (.jpg, .webp, .css, etc.), aliviando o servidor.